### PR TITLE
Allow local file and remote file to have different names.

### DIFF
--- a/test-kube/src/integration/groovy/se/laz/casual/test/tdk8s/integration/ConfigMapMountIntTest.groovy
+++ b/test-kube/src/integration/groovy/se/laz/casual/test/tdk8s/integration/ConfigMapMountIntTest.groovy
@@ -42,7 +42,7 @@ class ConfigMapMountIntTest extends Specification
     @Shared
     Path configFile = Paths.get("./src/integration/resources/configFile.txt")
     @Shared
-    String mountPath = "/data/configFile.txt"
+    String mountPath = "/data/configFile2.txt"
 
 
     def setupSpec()

--- a/test-kube/src/main/java/se/laz/casual/test/tdk8s/resources/ConfigMapFactory.java
+++ b/test-kube/src/main/java/se/laz/casual/test/tdk8s/resources/ConfigMapFactory.java
@@ -35,24 +35,45 @@ public final class ConfigMapFactory
      */
     public static ConfigMap fromFile( String name, Path file ) throws IOException
     {
-        validate( name, file );
-
-        return new ConfigMapBuilder()
-                .withNewMetadata()
-                    .withName( name )
-                .endMetadata()
-                .addToData( file.getFileName().toString(), Files.readString( file ) )
-                .build();
+        return fromFiles( name, file );
     }
 
-    private static void validate( String name, Path file )
+    /**
+     * Create a ConfigMap called name, with data from each of the files provided.
+     * The data key for the files will be the filename of the file path provided.
+     *
+     * @param name of the ConfigMap.
+     * @param files 1 or more files to read as data for the ConfigMap.
+     * @return ConfigMap containing the files.
+     * @throws IOException if there is an issue whilst reading the files.
+     */
+    public static ConfigMap fromFiles( String name, Path... files ) throws IOException
+    {
+        validate( name, files );
+
+        ConfigMapBuilder builder =  new ConfigMapBuilder()
+                .withNewMetadata()
+                .withName( name )
+                .endMetadata();
+        for( Path file: files )
+        {
+                builder.addToData( file.getFileName().toString(), Files.readString( file ) );
+        }
+        return builder.build();
+    }
+
+    private static void validate( String name, Path...files )
     {
         Objects.requireNonNull( name, "Name is null." );
-        Objects.requireNonNull( file, "File is null." );
+        Objects.requireNonNull( files, "Files is null." );
 
-        if( !Files.exists( file ) )
+        for( Path file: files )
         {
-            throw new IllegalArgumentException( "File does not exist." );
+            Objects.requireNonNull( file, "Files is null." );
+            if( !Files.exists( file ) )
+            {
+                throw new IllegalArgumentException( "File does not exist." );
+            }
         }
     }
 }

--- a/test-kube/src/main/java/se/laz/casual/test/tdk8s/resources/FileMount.java
+++ b/test-kube/src/main/java/se/laz/casual/test/tdk8s/resources/FileMount.java
@@ -119,7 +119,7 @@ public class FileMount
         }
 
         /**
-         * Optional - ConfigMap entry subpath to use as the file contents.
+         * Optional - ConfigMap entry (subpath) to use as the file contents.
          * <br/>
          * If not provided, the ConfigMap must have a single entry, which will be used.
          *

--- a/test-kube/src/main/java/se/laz/casual/test/tdk8s/resources/FileMount.java
+++ b/test-kube/src/main/java/se/laz/casual/test/tdk8s/resources/FileMount.java
@@ -19,13 +19,15 @@ public class FileMount
 
     private final ConfigMap configMap;
     private final String mountPath;
+    private final String subPath;
     private final String volume;
     private final String container;
 
-    private FileMount( ConfigMap configMap, String mountPath, String volume, String containerName )
+    private FileMount( ConfigMap configMap, String mountPath, String subPath, String volume, String containerName )
     {
         this.configMap = configMap;
         this.mountPath = mountPath;
+        this.subPath = subPath;
         this.volume = volume;
         this.container = containerName;
     }
@@ -47,6 +49,16 @@ public class FileMount
     public String getMountPath()
     {
         return mountPath;
+    }
+
+    /**
+     * The entry of the ConfigMap to use as the file.
+     *
+     * @return ConfigMap entry subpath.
+     */
+    public String getSubPath()
+    {
+        return subPath;
     }
 
     /**
@@ -78,6 +90,7 @@ public class FileMount
     {
         private ConfigMap configMap;
         private String mountPath;
+        private String subPath;
         private String volume = DEFAULT_VOLUME_NAME;
         private String container;
 
@@ -106,7 +119,23 @@ public class FileMount
         }
 
         /**
+         * Optional - ConfigMap entry subpath to use as the file contents.
+         * <br/>
+         * If not provided, the ConfigMap must have a single entry, which will be used.
+         *
+         * @param subPath of the ConfigMap to use.
+         * @return Builder.
+         */
+        public Builder subPath( String subPath )
+        {
+            this.subPath = subPath;
+            return this;
+        }
+
+        /**
          * Optional - volume name to mount the file.
+         * <br/>
+         * If not provided a default name will be used.
          *
          * @param volume name of the volume.
          * @return Builder.
@@ -119,6 +148,8 @@ public class FileMount
 
         /**
          * Optional - name of the container to mount the file upon.
+         *<br/>
+         * If not provided the first container will be used.
          *
          * @param container name to mount the file upon.
          * @return Builder.
@@ -134,7 +165,27 @@ public class FileMount
             Objects.requireNonNull( configMap, "ConfigMap is null." );
             Objects.requireNonNull( mountPath, "Mount path is null."  );
 
-            return new FileMount( configMap, mountPath, volume, container );
+            this.subPath = confirmValidSubPath( );
+
+            return new FileMount( configMap, mountPath, subPath, volume, container );
+        }
+
+        private String confirmValidSubPath( )
+        {
+            if( this.subPath == null )
+            {
+                if( this.configMap.getData().size() != 1 )
+                {
+                    throw new IllegalArgumentException( "ConfigMap contains multiple entries without a specified subpath." );
+                }
+                return this.configMap.getData().keySet().iterator().next();
+            }
+
+            if( !this.configMap.getData().containsKey( this.subPath ) )
+            {
+                throw new IllegalArgumentException( "ConfigMap does not contain an entry: " + this.subPath );
+            }
+            return this.subPath;
         }
     }
 }

--- a/test-kube/src/main/java/se/laz/casual/test/tdk8s/resources/VolumeMounter.java
+++ b/test-kube/src/main/java/se/laz/casual/test/tdk8s/resources/VolumeMounter.java
@@ -10,7 +10,6 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import se.laz.casual.test.tdk8s.store.ResourceNotFoundException;
 
-import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.function.IntSupplier;
 
@@ -89,7 +88,7 @@ public final class VolumeMounter
                         .addNewVolumeMount()
                             .withName( mount.getVolume() )
                             .withMountPath( mount.getMountPath() )
-                            .withSubPath( Paths.get( mount.getMountPath() ).getFileName().toString() )
+                            .withSubPath( mount.getSubPath() )
                         .endVolumeMount()
                     .endContainer()
                 .endSpec()
@@ -110,7 +109,7 @@ public final class VolumeMounter
                                 .addNewVolumeMount()
                                     .withName( mount.getVolume() )
                                     .withMountPath( mount.getMountPath() )
-                                    .withSubPath( Paths.get( mount.getMountPath() ).getFileName().toString() )
+                                    .withSubPath( mount.getSubPath() )
                                 .endVolumeMount()
                             .endContainer()
                         .endSpec()

--- a/test-kube/src/test/groovy/se/laz/casual/test/tdk8s/resources/ConfigMapFactoryTest.groovy
+++ b/test-kube/src/test/groovy/se/laz/casual/test/tdk8s/resources/ConfigMapFactoryTest.groovy
@@ -65,4 +65,56 @@ class ConfigMapFactoryTest extends Specification
             Paths.get( "src/test/resources/invalid.txt")
         ]
     }
+
+    def "Create with multiple files."()
+    {
+        given:
+        String mapName = "mymap"
+        Path file = Paths.get( "src/test/resources/test.txt" )
+        Path file2 = Paths.get( "src/test/resources/test2.txt" )
+
+        ConfigMap expected = new ConfigMapBuilder(  )
+                .withNewMetadata(  )
+                .withName( mapName )
+                .endMetadata(  )
+                .addToData( "test.txt", Files.readString( file ) )
+                .addToData( "test2.txt", Files.readString( file2 ) )
+                .build(  )
+
+        when:
+        ConfigMap actual = ConfigMapFactory.fromFiles( mapName, file, file2 )
+
+        then:
+        actual == expected
+    }
+
+    def "Create with multiple files, with non existent file throws IllegalArgumentException."()
+    {
+        given:
+        String mapName = "mymap"
+        Path file = Paths.get( "src/test/resources/test.txt" )
+        Path file2 = Paths.get( "src/test/resources/invalid.txt" )
+
+        when:
+        ConfigMapFactory.fromFiles( mapName, file, file2 )
+
+        then:
+        thrown IllegalArgumentException
+    }
+
+    def "Create with nulls, throws NullPointerException."()
+    {
+        when:
+        ConfigMapFactory.fromFiles( name, file, file2 )
+
+        then:
+        thrown NullPointerException
+
+        where:
+        name  | file                                       | file2
+        "map" | Paths.get( "src/test/resources/test.txt" ) | null
+        "map" | null                                       | Paths.get( "src/test/resources/test2.txt" )
+        null  | Paths.get( "src/test/resources/test.txt" ) | Paths.get( "src/test/resources/test2.txt" )
+        null  | null                                       | null
+    }
 }

--- a/test-kube/src/test/groovy/se/laz/casual/test/tdk8s/resources/FileMountTest.groovy
+++ b/test-kube/src/test/groovy/se/laz/casual/test/tdk8s/resources/FileMountTest.groovy
@@ -18,7 +18,13 @@ class FileMountTest extends Specification
     @Shared
     ConfigMap map = ConfigMapFactory.fromFile( "my-map", Paths.get( "src/test/resources/test.txt") )
     @Shared
+    ConfigMap multiMap = ConfigMapFactory.fromFiles( "my-multi-map",
+            Paths.get( "src/test/resources/test.txt"),
+            Paths.get( "src/test/resources/test2.txt"))
+    @Shared
     String mountPath = "/mnt/test.txt"
+    @Shared
+    String subPath = "test.txt"
     @Shared
     String volume = "custom-vol-01"
     @Shared
@@ -30,6 +36,7 @@ class FileMountTest extends Specification
         FileMount instance = FileMount.newBuilder()
                 .configMap( map )
                 .mountPath( mountPath )
+                .subPath( subPath )
                 .volume( volume )
                 .container( container )
                 .build()
@@ -37,6 +44,7 @@ class FileMountTest extends Specification
         then:
         instance.getConfigMap() == map
         instance.getMountPath() == mountPath
+        instance.getSubPath() == subPath
         instance.getVolume() == volume
         instance.getContainer() == container
     }
@@ -54,6 +62,45 @@ class FileMountTest extends Specification
         instance.getMountPath() == mountPath
         instance.getVolume() == FileMount.DEFAULT_VOLUME_NAME
         instance.getContainer() == null
+        instance.getSubPath() == "test.txt"
+    }
+
+    def "Subpath validation correct."()
+    {
+        when:
+        FileMount instance = FileMount.newBuilder()
+                .configMap( cm )
+                .mountPath( mountPath )
+                .subPath( path )
+                .build(  )
+
+        then:
+        instance.getSubPath(  ) == expected
+
+        where:
+        cm       | path        | expected
+        map      | null        | "test.txt"
+        multiMap | "test.txt"  | "test.txt"
+        multiMap | "test2.txt" | "test2.txt"
+    }
+
+    def "Subpath validation exceptional."()
+    {
+        when:
+        FileMount.newBuilder()
+                .configMap( cm )
+                .mountPath( mountPath )
+                .subPath( path )
+                .build(  )
+
+        then:
+        thrown IllegalArgumentException
+
+        where:
+        cm       | path
+        map      | "invalid.txt"
+        multiMap | "invalid.txt"
+        multiMap | null
     }
 
 }

--- a/test-kube/src/test/groovy/se/laz/casual/test/tdk8s/resources/VolumeMounterTest.groovy
+++ b/test-kube/src/test/groovy/se/laz/casual/test/tdk8s/resources/VolumeMounterTest.groovy
@@ -140,6 +140,46 @@ class VolumeMounterTest extends Specification
         null                            | null
     }
 
+    def "Add pod volume mount with different mountpath file name for configmap."()
+    {
+        given:
+        String volumeName = "tdk8s-vol-01"
+        String container = NginxResources.NGINX_CONTAINER_NAME
+        String mountPath = "/data/test2.txt"
+        String subPath = "test.txt"
+        Pod pod = NginxResources.SIMPLE_NGINX_POD
+
+        FileMount mount = FileMount.newBuilder().configMap( map )
+                .mountPath( mountPath )
+                .container( container )
+                .volume( volumeName )
+                .build()
+
+        Pod expected = pod.edit(  )
+                .editSpec(  )
+                .addNewVolume(  )
+                .withName( volumeName )
+                .withNewConfigMap(  )
+                .withName( mapName )
+                .endConfigMap(  )
+                .endVolume(  )
+                .editContainer( 0 )
+                .addNewVolumeMount(  )
+                .withName( volumeName )
+                .withMountPath( mountPath )
+                .withSubPath( subPath )
+                .endVolumeMount(  )
+                .endContainer(  )
+                .endSpec(  )
+                .build(  )
+
+        when:
+        Pod actual = VolumeMounter.mount( pod, mount )
+
+        then:
+        actual == expected
+    }
+
     def "Add deployment volume mount for configmap."()
     {
         given:
@@ -257,6 +297,48 @@ class VolumeMounterTest extends Specification
         NginxResources.SIMPLE_NGINX_DEPLOYMENT | null
         null                                   | FileMount.newBuilder().configMap( map ).mountPath( "/tmp/t.log" ).build()
         null                                   | null
+    }
+
+    def "Add deployment volume mount with different mountpath file name for configmap."()
+    {
+        given:
+        String volumeName = "tdk8s-vol-0"
+        String container = NginxResources.NGINX_CONTAINER_NAME
+        String mountPath = "/data/test2.txt"
+        String subPath = "test.txt"
+        Deployment deployment = NginxResources.SIMPLE_NGINX_DEPLOYMENT
+
+        FileMount mount = FileMount.newBuilder().configMap( map )
+                .mountPath( mountPath )
+                .container( container )
+                .volume( volumeName )
+                .build()
+
+        Deployment expected = deployment.edit(  )
+                .editSpec(  )
+                .editTemplate(  ).editSpec(  )
+                .addNewVolume(  )
+                .withName( volumeName )
+                .withNewConfigMap(  )
+                .withName( mapName )
+                .endConfigMap(  )
+                .endVolume(  )
+                .editContainer( 0 )
+                .addNewVolumeMount(  )
+                .withName( volumeName )
+                .withMountPath( mountPath )
+                .withSubPath( subPath )
+                .endVolumeMount(  )
+                .endContainer(  )
+                .endSpec(  )
+                .endTemplate(  ).endSpec(  )
+                .build(  )
+
+        when:
+        Deployment actual = VolumeMounter.mount( deployment, mount )
+
+        then:
+        actual == expected
     }
 
 }

--- a/test-kube/src/test/resources/test2.txt
+++ b/test-kube/src/test/resources/test2.txt
@@ -1,0 +1,1 @@
+this is another file that can also be an entry in a config map.

--- a/versions.gradle
+++ b/versions.gradle
@@ -6,7 +6,7 @@
 
 // casual-java group and version
 group = 'se.laz.casual'
-version = '0.0.3-beta'
+version = '0.0.4-beta'
 
 ext.libs = [
   fabric8: 'io.fabric8:kubernetes-client:7.3.1',


### PR DESCRIPTION
* Currently file mount only works if filename of local file and remote file matched. This restriction is now removed allowing arbitrary naming of remote file mountPath no matter the name of local file name.